### PR TITLE
Fixes issue with scrollbar appearing after resizing visualization

### DIFF
--- a/public/vis/index.js
+++ b/public/vis/index.js
@@ -25,7 +25,7 @@ function vis() {
       chart.options(opts);
 
       d3.select(this)
-        .attr('width', size[0])
+        .attr('width', '100%')
         .attr('height', size[1])
         .call(events)
         .call(layout)


### PR DESCRIPTION
Closes #6.

Horizontal scrollbars appear after resizing visualizations. This originally occurred in IE, but also occurred in Chrome.

Setting the width to 100% seems to fix the issue. Suggestion from @Prazzy from [here](https://github.com/stormpython/heatmap/issues/8).
