### PR TITLE
Compatibility with Kibana 5.0 per Issue #12

### DIFF
--- a/public/cloud.js
+++ b/public/cloud.js
@@ -3,8 +3,8 @@ require('plugins/tagcloud/lib/cloud_controller.js');
 require('plugins/tagcloud/lib/cloud_directive.js');
 
 function TagCloudProvider(Private) {
-  var TemplateVisType = Private(require('ui/template_vis_type/TemplateVisType'));
-  var Schemas = Private(require('ui/Vis/Schemas'));
+  var TemplateVisType = Private(require('ui/template_vis_type/template_vis_type'));
+  var Schemas = Private(require('ui/Vis/schemas'));
 
   return new TemplateVisType({
     name: 'tagcloud',


### PR DESCRIPTION
As per your note on: https://github.com/stormpython/tagcloud/issues/12

ranahaarb commented 16 hours ago
It works for kibana 5, only with a bit changes:
In the file "tagcloud/public/cloud.js", line 6 and 7 must be changed to:

var TemplateVisType = Private(require('ui/template_vis_type/template_vis_type')); var Schemas = Private(require('ui/vis/schemas'));
